### PR TITLE
IconPackHelper:Use un-tinted iconback when no defaultSwatchcolor is s…

### DIFF
--- a/core/java/android/app/ComposedIconInfo.java
+++ b/core/java/android/app/ComposedIconInfo.java
@@ -74,11 +74,9 @@ public class ComposedIconInfo implements Parcelable {
         iconPaletteBack = source.readInt();
         swatchType = SwatchType.values()[source.readInt()];
         int numDefaultColors = source.readInt();
-        if (numDefaultColors > 0) {
-            defaultSwatchColors = new int[numDefaultColors];
-            for (int i = 0; i < numDefaultColors; i++) {
-                defaultSwatchColors[i] = source.readInt();
-            }
+        defaultSwatchColors = new int[numDefaultColors];
+        for (int i = 0; i < numDefaultColors; i++) {
+            defaultSwatchColors[i] = source.readInt();
         }
     }
 


### PR DESCRIPTION
…pecified

After applying the theme which supports paletteback feature and if there is
no defaultSwatchColor specified then the background should go to the
original color. Instead in a particular FootballDemo theme the theme
would never get applied and just flood the logcat with null exceptions
for each and every app.

TICKET:CYNGNOS-2942

Change-Id: If2bd3d23ab5075dac1d8ff3f197cebc28c9c1f20