### PR TITLE
pm: resolver: Don't hold the lock when calling into the resolver

### DIFF
--- a/services/core/java/com/android/server/pm/PackageManagerService.java
+++ b/services/core/java/com/android/server/pm/PackageManagerService.java
@@ -4734,11 +4734,10 @@ public class PackageManagerService extends IPackageManager.Stub {
         if (!mSystemReady || mOnlyCore) {
             return false;
         }
-        synchronized(mPackages) {
-            AppSuggestManager suggest = AppSuggestManager.getInstance(mContext);
-            return mResolverReplaced && (suggest.getService() != null) ?
-                    suggest.handles(intent) : false;
-        }
+
+        AppSuggestManager suggest = AppSuggestManager.getInstance(mContext);
+        return mResolverReplaced && (suggest.getService() != null) ?
+                suggest.handles(intent) : false;
     }
 
     @Override


### PR DESCRIPTION
This lock isn't really needed because the proxy will return
false if the resolver package doesn't exist or throws a
remote exception.

Having this lock causes a deadlock between the PM and the app:

resolveIntent holds the PackageManagerService#mPackages lock and
then tries to lock on PackageMonitor#mLock.

Meanwhile, when packages change, LaodedApk holds onto the
PackageMonitor#mLock and then tries to query the intent services and
tries to lock on PackageManagerService#mPackages.

Relevant traces below:
"Binder_4" prio=5 tid=60 Blocked
  | group="main" sCount=1 dsCount=0 obj=0x136f00a0 self=0x7f743d2a00
  | sysTid=949 nice=0 cgrp=default sched=0/0 handle=0x7f74b93440
  | state=S schedstat=( 1032333944 663457790 2968 ) utm=74 stm=29 core=3 HZ=100
  | stack=0x7f74a97000-0x7f74a99000 stackSize=1013KB
  | held mutexes=
  at com.android.server.ServiceWatcher.getBinder(ServiceWatcher.java:368)
  - waiting to lock <0x083e77c9> (a java.lang.Object) held by thread 9
  at org.cyanogenmod.platform.internal.AppSuggestProviderProxy.getService(AppSuggestProviderProxy.java:68)
  at org.cyanogenmod.platform.internal.AppSuggestProviderProxy.handles(AppSuggestProviderProxy.java:73)
  at org.cyanogenmod.platform.internal.AppSuggestManagerService$1.handles(AppSuggestManagerService.java:50)
  at cyanogenmod.app.suggest.AppSuggestManager.handles(AppSuggestManager.java:101)
  at com.android.server.pm.PackageManagerService.shouldIncludeResolveActivity(PackageManagerService.java:4704)
  - locked <0x0183dd64> (a android.util.ArrayMap)
  at com.android.server.pm.PackageManagerService.chooseBestActivity(PackageManagerService.java:4430)
  at com.android.server.pm.PackageManagerService.resolveIntent(PackageManagerService.java:4353)
  at android.content.pm.IPackageManager$Stub.onTransact(IPackageManager.java:628)
  at com.android.server.pm.PackageManagerService.onTransact(PackageManagerService.java:2754)
  at android.os.Binder.execTransact(Binder.java:453)

"android.bg" prio=5 tid=9 Blocked
  | group="main" sCount=1 dsCount=0 obj=0x12c04b80 self=0x7f84a7d800
  | sysTid=766 nice=10 cgrp=bg_non_interactive sched=0/0 handle=0x7f89b3f440
  | state=S schedstat=( 1237112536 3291977271 2848 ) utm=62 stm=61 core=2 HZ=100
  | stack=0x7f89a3d000-0x7f89a3f000 stackSize=1037KB
  | held mutexes=
  at com.android.server.pm.PackageManagerService.queryIntentServices(PackageManagerService.java:5405)
  - waiting to lock <0x0183dd64> (a android.util.ArrayMap) held by thread 60
  at android.app.ApplicationPackageManager.queryIntentServicesAsUser(ApplicationPackageManager.java:731)
  at com.android.server.ServiceWatcher.bindBestPackageLocked(ServiceWatcher.java:167)
  at com.android.server.ServiceWatcher.-wrap0(ServiceWatcher.java:-1)
  at com.android.server.ServiceWatcher$1.onPackageChanged(ServiceWatcher.java:321)
  - locked <0x083e77c9> (a java.lang.Object)
  at com.android.internal.content.PackageMonitor.onReceive(PackageMonitor.java:352)
  at android.app.LoadedApk$ReceiverDispatcher$Args.run(LoadedApk.java:882)
  at android.os.Handler.handleCallback(Handler.java:739)
  at android.os.Handler.dispatchMessage(Handler.java:95)
  at android.os.Looper.loop(Looper.java:148)
  at android.os.HandlerThread.run(HandlerThread.java:61)

Change-Id: Id4775ca4d12b6cf42bea97bd74e4c38d591a1cf3